### PR TITLE
Revert "Replace curl nomad installation with hashicorp/setup-nomad GitHub Action"

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,13 +45,12 @@ jobs:
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
 
-    - name: Setup Nomad CLI
-      uses: hashicorp/setup-nomad@v1
-      with:
-        version: '1.10.5'
-
-    - name: Verify Nomad installation
-      run: nomad version
+    - name: Install Nomad CLI
+      run: |
+        curl -fsSL https://releases.hashicorp.com/nomad/1.10.5/nomad_1.10.5_linux_amd64.zip -o nomad.zip
+        unzip nomad.zip
+        sudo mv nomad /usr/local/bin/
+        nomad version
 
     - name: Update Nomad job with new image tag
       run: |


### PR DESCRIPTION
Reverts st3fan/hello-nomad-deployment#4

Their action does not actually work or is stale.